### PR TITLE
Allow dialog summary to wrap

### DIFF
--- a/app/assets/javascripts/recurring_select_dialog.js.coffee.erb
+++ b/app/assets/javascripts/recurring_select_dialog.js.coffee.erb
@@ -45,7 +45,7 @@ window.RecurringSelectDialog =
 
       new_style_hash =
         "margin-top" : margin_top+"px"
-        "height" : dialog_height+"px"
+        "min-height" : dialog_height+"px"
 
       if initial_positioning?
         @inner_holder.css new_style_hash
@@ -153,6 +153,7 @@ window.RecurringSelectDialog =
 # ========================= render methods ===============================
 
     summaryUpdate: (new_string) =>
+      @summary.width @content.width()
       if @current_rule.hash? && @current_rule.str?
         @summary.removeClass "fetching"
         @save_button.removeClass("disabled")

--- a/app/assets/stylesheets/recurring_select.css.scss.erb
+++ b/app/assets/stylesheets/recurring_select.css.scss.erb
@@ -30,7 +30,7 @@ select {
 
 .rs_dialog_holder { position:fixed; left:0px; right:0px; top:0px; bottom:0px; padding-left:50%; background-color:rgba(255,255,255,0.2); z-index:50;
   .rs_dialog { background-color:#f6f6f6; border:1px solid #acacac; @include shadows(1px, 3px, 8px, rgba(0,0,0,0.25)); @include rounded_corners(7px);
-              display:inline-block; min-width:200px; margin-left:-125px; overflow:hidden; height:25px; position:relative;
+              display:inline-block; min-width:200px; margin-left:-125px; overflow:hidden; position:relative;
     .rs_dialog_content { padding:10px;
       h1 { font-size:16px; padding:0px; margin:0 0 10px 0;
         a {float:right; display:inline-block; height:16px; width:16px; background-image:url(<%=asset_path "recurring_select/cancel.png"%>); background-position:center; background-repeat:no-repeat;}


### PR DESCRIPTION
Currently even if the summary is extremely long (i.e. select weekly and
check all the days of the week), it just keeps growing in width and it
expands the size of the dialog box as well. I limited the width of the
summary to the width of the dialog.
