### PR TITLE
dirty_hash_to_rule was modifying it's argument

### DIFF
--- a/lib/recurring_select.rb
+++ b/lib/recurring_select.rb
@@ -11,7 +11,7 @@ module RecurringSelect
         params = JSON.parse(params)
       end
 
-      params.symbolize_keys!
+      params = params.symbolize_keys
       rules_hash = filter_params(params)
 
       IceCube::Rule.from_hash(rules_hash)


### PR DESCRIPTION
... causing other bugs to creep in.

One bug caused by this, was that when editing a form with recurring_select, the currently rule would never be selected in the list. This was only noticeable when "allow_blank" was not set, because then the current rule was not the first item in the list, and so it was quite noticeable when it was not actually selected.
