### PR TITLE
If schedule is a hash on the model, then need to check for empty hash as well

### DIFF
--- a/app/helpers/utilities/form_options_ext.rb
+++ b/app/helpers/utilities/form_options_ext.rb
@@ -8,7 +8,7 @@ module RecurringSelectHelper
       separator = [I18n.t("recurring_select.or"), {:disabled => true}]
 
       if default_schedules.blank?
-        if currently_selected_rule
+        if not currently_selected_rule.blank?
           options_array << blank_option if options[:allow_blank]
           options_array << ice_cube_rule_to_option(currently_selected_rule)
           options_array << separator
@@ -24,7 +24,7 @@ module RecurringSelectHelper
           ice_cube_rule_to_option(dc)
         }
 
-        if currently_selected_rule and not current_rule_in_defaults?(currently_selected_rule, default_schedules)
+        if not currently_selected_rule.blank? and not current_rule_in_defaults?(currently_selected_rule, default_schedules)
           options_array << ice_cube_rule_to_option(currently_selected_rule, true)
           custom_label = [I18n.t("recurring_select.new_custom_schedule"), "custom"]
         else


### PR DESCRIPTION
If you save an blank/empty rule, it could get serialized as an empty hash {}  (depending on your code).

So a more robust solution should be able to handle empty hashes as well, and treat them the same as if they were blank/empty/nil.
