### PR TITLE
Fix allow_blank example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ f.select_recurring :current_existing_rule, [
 
 :allow_blank let's you pick if there is a "not recurring" value
 ```
-  f.select_recurring :current_existing_rule, :allow_blank => true
+  f.select_recurring :current_existing_rule, nil, :allow_blank => true
 ```
 
 


### PR DESCRIPTION
You need to pass something in for default_schedules if you want to
use the options hash. Otherwise you will end up with a weird
'allow_blank' option in your dropdown.
