### PR TITLE
Fix hidden dialog when called from Bootstrap modal.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ spec/dummy/.sass-cache
 .DS_Store
 *.sublime-workspace
 
+.idea

--- a/app/assets/javascripts/recurring_select_dialog.js.coffee.erb
+++ b/app/assets/javascripts/recurring_select_dialog.js.coffee.erb
@@ -13,6 +13,7 @@ window.RecurringSelectDialog =
 
       open_in = $("body")
       open_in = $(".ui-page-active") if $(".ui-page-active").length
+      open_in = $(".modal") if $(".modal:visible").length
       open_in.append @template()
       @outer_holder = $(".rs_dialog_holder")
       @inner_holder = @outer_holder.find ".rs_dialog"


### PR DESCRIPTION
Dialog would appear underneath Bootstrap modals if they were being used as a form.
![screen shot 2014-03-14 at 8 35 48 pm](https://f.cloud.github.com/assets/4166438/2427367/3183dde0-abe2-11e3-8a0a-149febcecb2a.png)
![screen shot 2014-03-14 at 8 34 10 pm](https://f.cloud.github.com/assets/4166438/2427368/3189388a-abe2-11e3-91f4-65bd39ade535.png)
