### PR TITLE
Fixes issue with "null" being displayed in drop down

### DIFF
--- a/app/helpers/recurring_select_helper.rb
+++ b/app/helpers/recurring_select_helper.rb
@@ -28,7 +28,7 @@ module RecurringSelectHelper
 
       options_array = []
       blank_option_label = options[:blank_label] || I18n.t("recurring_select.not_recurring")
-      blank_option = [blank_option_label, "null"]
+      blank_option = [blank_option_label, nil]
       separator = [I18n.t("recurring_select.or"), {:disabled => true}]
 
       if default_schedules.blank?

--- a/spec/app/helpers/recurring_select_helper_spec.rb
+++ b/spec/app/helpers/recurring_select_helper_spec.rb
@@ -11,7 +11,7 @@ describe RecurringSelectHelper do
       subject = FromTester.new
       subject.should_receive(:options_for_select).with(
         [
-          ['- not recurring -', 'null'],
+          ['- not recurring -', nil],
           ['Set schedule...', 'custom']
         ], 'null'
       )
@@ -47,7 +47,7 @@ describe RecurringSelectHelper do
       subject = FromTester.new
       subject.should_receive(:options_for_select).with(
         [
-          ["- not recurring -", 'null'],
+          ["- not recurring -", nil],
           ["different", 1],
           ["Weekly", IceCube::Rule.weekly.to_hash.to_json],
           ['or', {:disabled => true}],


### PR DESCRIPTION
All the code checks for presence, but the db stores the string “null”.

For backwards compatibility, the fix could be to update all the checks
to ensure that “null” is considered a blank string essentially, but for
our project adding this for the first time we decided to just store nil
in the database as the proper solution.
