### PR TITLE
Hourly option - disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Options include:
 
 ```coffeescript
 $.fn.recurring_select.options = {
+  hourly: {
+    enable: true //enable hourly option - disabled by default
+  },
   monthly: {
     show_week: [true, true, true, true, false, false] //display week 1, 2 .... Last
   }

--- a/app/assets/javascripts/recurring_select.js.coffee
+++ b/app/assets/javascripts/recurring_select.js.coffee
@@ -74,6 +74,9 @@ $.fn.recurring_select = (method) ->
     $.error( "Method #{method} does not exist on jQuery.recurring_select" );
 
 $.fn.recurring_select.options = {
+  hourly: {
+    enable: false
+  },
   monthly: {
     show_week: [true, true, true, true, false, false]
   }
@@ -84,11 +87,13 @@ $.fn.recurring_select.texts = {
   repeat: "Repeat"
   last_day: "Last Day"
   frequency: "Frequency"
+  hourly: "Hourly"
   daily: "Daily"
   weekly: "Weekly"
   monthly: "Monthly"
   yearly: "Yearly"
   every: "Every"
+  hours: "hour(s)"
   days: "day(s)"
   weeks_on: "week(s) on"
   months: "month(s)"

--- a/app/assets/javascripts/recurring_select_dialog.js.coffee.erb
+++ b/app/assets/javascripts/recurring_select_dialog.js.coffee.erb
@@ -73,19 +73,31 @@ window.RecurringSelectDialog =
 
     freqInit: ->
       @freq_select = @outer_holder.find ".rs_frequency"
+      hourly_option_enabled = $.fn.recurring_select.options["hourly"]["enable"]
       if @current_rule.hash? && (rule_type = @current_rule.hash.rule_type)?
-        if rule_type.search(/Weekly/) != -1
-          @freq_select.prop('selectedIndex', 1)
+        if rule_type.search(/Hourly/) != -1
+          @freq_select.prop('selectedIndex', 0)
+          @initHourlyOptions()
+        else if rule_type.search(/Weekly/) != -1
+          @freq_select.prop('selectedIndex', if hourly_option_enabled then 2 else 1)
           @initWeeklyOptions()
         else if rule_type.search(/Monthly/) != -1
-          @freq_select.prop('selectedIndex', 2)
+          @freq_select.prop('selectedIndex', if hourly_option_enabled then 3 else 2)
           @initMonthlyOptions()
         else if rule_type.search(/Yearly/) != -1
-          @freq_select.prop('selectedIndex', 3)
+          @freq_select.prop('selectedIndex', if hourly_option_enabled then 4 else 3)
           @initYearlyOptions()
         else
+          @freq_select.prop('selectedIndex', if hourly_option_enabled then 1 else 0)
           @initDailyOptions()
       @freq_select.on "change", @freqChanged
+
+    initHourlyOptions: ->
+      section = @content.find('.hourly_options')
+      interval_input = section.find('.rs_hourly_interval')
+      interval_input.val(@current_rule.hash.interval)
+      interval_input.on "change keyup", @intervalChanged
+      section.show()
 
     initDailyOptions: ->
       section = @content.find('.daily_options')
@@ -233,6 +245,10 @@ window.RecurringSelectDialog =
       @content.find(".freq_option_section").hide();
       @content.find("input[type=radio], input[type=checkbox]").prop("checked", false)
       switch @freq_select.val()
+        when "Hourly"
+          @current_rule.hash.rule_type = "IceCube::HourlyRule"
+          @current_rule.str = $.fn.recurring_select.texts["hourly"]
+          @initHourlyOptions()
         when "Weekly"
           @current_rule.hash.rule_type = "IceCube::WeeklyRule"
           @current_rule.str = $.fn.recurring_select.texts["weekly"]
@@ -309,27 +325,41 @@ window.RecurringSelectDialog =
             <p class='frequency-select-wrapper'>
               <label for='rs_frequency'>#{$.fn.recurring_select.texts["frequency"]}:</label>
               <select data-wrapper-class='ui-recurring-select' id='rs_frequency' class='rs_frequency' name='rs_frequency'>
-                <option value='Daily'>#{$.fn.recurring_select.texts["daily"]}</option>
-                <option value='Weekly'>#{$.fn.recurring_select.texts["weekly"]}</option>
-                <option value='Monthly'>#{$.fn.recurring_select.texts["monthly"]}</option>
-                <option value='Yearly'>#{$.fn.recurring_select.texts["yearly"]}</option>
-              </select>
-            </p>
+      "
+      if $.fn.recurring_select.options["hourly"]["enable"] is true
+        str += "<option value='Hourly'>#{$.fn.recurring_select.texts["hourly"]}</option>"
 
-            <div class='daily_options freq_option_section'>
-              <p>
-                #{$.fn.recurring_select.texts["every"]}
-                <input type='text' data-wrapper-class='ui-recurring-select' name='rs_daily_interval' class='rs_daily_interval rs_interval' value='1' size='2' />
-                #{$.fn.recurring_select.texts["days"]}
-              </p>
-            </div>
-            <div class='weekly_options freq_option_section'>
-              <p>
-                #{$.fn.recurring_select.texts["every"]}
-                <input type='text' data-wrapper-class='ui-recurring-select' name='rs_weekly_interval' class='rs_weekly_interval rs_interval' value='1' size='2' />
-                #{$.fn.recurring_select.texts["weeks_on"]}:
-              </p>
-              <div class='day_holder'>
+      str += "<option value='Daily' selected=true>#{$.fn.recurring_select.texts["daily"]}</option>
+              <option value='Weekly'>#{$.fn.recurring_select.texts["weekly"]}</option>
+              <option value='Monthly'>#{$.fn.recurring_select.texts["monthly"]}</option>
+              <option value='Yearly'>#{$.fn.recurring_select.texts["yearly"]}</option>
+            </select>
+          </p>
+      "
+      if $.fn.recurring_select.options["hourly"]["enable"] is true
+        str += "<div class='hourly_options freq_option_section'>
+                <p>
+                  #{$.fn.recurring_select.texts["every"]}
+                  <input type='text' data-wrapper-class='ui-recurring-select' name='rs_hourly_interval' class='rs_hourly_interval rs_interval' value='1' size='2' />
+                  #{$.fn.recurring_select.texts["hours"]}
+                </p>
+              </div>
+        "
+
+      str += "<div class='daily_options freq_option_section'>
+                <p>
+                  #{$.fn.recurring_select.texts["every"]}
+                  <input type='text' data-wrapper-class='ui-recurring-select' name='rs_daily_interval' class='rs_daily_interval rs_interval' value='1' size='2' />
+                  #{$.fn.recurring_select.texts["days"]}
+                </p>
+              </div>
+              <div class='weekly_options freq_option_section'>
+                <p>
+                  #{$.fn.recurring_select.texts["every"]}
+                  <input type='text' data-wrapper-class='ui-recurring-select' name='rs_weekly_interval' class='rs_weekly_interval rs_interval' value='1' size='2' />
+                  #{$.fn.recurring_select.texts["weeks_on"]}:
+                </p>
+                <div class='day_holder'>
       "
       for day_of_week in [$.fn.recurring_select.texts["first_day_of_week"]...(7 + $.fn.recurring_select.texts["first_day_of_week"])]
         day_of_week = day_of_week % 7

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -10,6 +10,9 @@
 //= require_tree .
 
 $.fn.recurring_select.options = {
+  hourly: {
+    enable: true
+  },
   monthly: {
     show_week: [true, true, true, true, true, true]
   }


### PR DESCRIPTION
Added hourly rule which, when enabled, shows as first option in frequency select. Assuming hourly rules are not needed in most cases this feature is disabled by default. Can be enabled via options feature:

``` coffeescript
$.fn.recurring_select.options = {
  hourly: {
    enable: true //enable hourly option - disabled by default
  },
  monthly: {
    show_week: [true, true, true, true, false, false] //display week 1, 2 .... Last
  }
}
```

![screen-capture](https://cloud.githubusercontent.com/assets/3581331/7016768/bad378f2-dd2e-11e4-9e44-d6968d859fcf.png)
