### PR TITLE
fix cannot modify frozen string error in modern rubys

### DIFF
--- a/lib/helpers/recurring_select_helper.rb
+++ b/lib/helpers/recurring_select_helper.rb
@@ -65,7 +65,7 @@ module RecurringSelectHelper
       ar = [rule.to_s, rule.to_hash.to_json]
 
       if custom
-        ar[0] << "*"
+        ar[0] += "*"
         ar << {"data-custom" => true}
       end
 


### PR DESCRIPTION
when rendering custom options, the code is trying to append to a frozen string which causes errors in later versions of ruby 