### PR TITLE
repair `data-custom` options

### DIFF
--- a/app/assets/javascripts/recurring_select_dialog.js.erb
+++ b/app/assets/javascripts/recurring_select_dialog.js.erb
@@ -276,7 +276,7 @@ class RecurringSelectDialog {
 // ========================= Change callbacks ===============================
 
   freqChanged() {
-    if (isPlainObject(this.current_rule.hash)) { this.current_rule.hash = null; } // for custom values
+    if (!isPlainObject(this.current_rule.hash)) { this.current_rule.hash = null; } // for custom values
 
     if (!this.current_rule.hash) { this.current_rule.hash = {} };
     this.current_rule.hash.interval = 1;


### PR DESCRIPTION
fix conditional. the original (coffeescript) used `unless`. the purpose here is to reset state if the value of the option is _no_ object.