### PR TITLE
JOB-114319 Fix JS error for option value 0

### DIFF
--- a/app/assets/javascripts/recurring_select_dialog.js.erb
+++ b/app/assets/javascripts/recurring_select_dialog.js.erb
@@ -77,7 +77,7 @@ class RecurringSelectDialog {
   freqInit() {
     this.freq_select = this.outer_holder.querySelector(".rs_frequency");
     const rule_type = this.current_rule.hash && this.current_rule.hash.rule_type
-    if (this.current_rule.hash != null && rule_type != null) {
+    if (this.current_rule.hash != null && rule_type) {
       if (rule_type.search(/Weekly/) !== -1) {
         this.freq_select.selectedIndex = 1
         this.initWeeklyOptions();

--- a/app/assets/javascripts/recurring_select_dialog.js.erb
+++ b/app/assets/javascripts/recurring_select_dialog.js.erb
@@ -77,7 +77,7 @@ class RecurringSelectDialog {
   freqInit() {
     this.freq_select = this.outer_holder.querySelector(".rs_frequency");
     const rule_type = this.current_rule.hash && this.current_rule.hash.rule_type
-    if (this.current_rule.hash != null && rule_type) {
+    if (rule_type) {
       if (rule_type.search(/Weekly/) !== -1) {
         this.freq_select.selectedIndex = 1
         this.initWeeklyOptions();


### PR DESCRIPTION
When checking if a `rule_type` exists, check for any "falsy" values, not just `null`.

### Before
When an option is selected that has a value of 0 (zero), when another option is selected there is a JS error thrown

### After
No JS error is thrown